### PR TITLE
Extended classes get appended with pseudo classes

### DIFF
--- a/lost.js
+++ b/lost.js
@@ -10,8 +10,22 @@ var postcss = require('postcss'),
  */
 module.exports = postcss.plugin('lost', function lost(settings) {
   var newBlock = function (decl, selector, props, values) {
-    var block = decl.parent.cloneAfter({
-          selector: decl.parent.selector + selector
+    var appendToSelectors, completeSelector, block;
+    
+    appendToSelectors = function (selector, selectorToAppend) {
+      var appendedSelectors = [];
+
+      selector.split(',').forEach(function(item) {
+        appendedSelectors.push(item + selectorToAppend);
+      });
+
+      return appendedSelectors.join(',');
+    };
+
+    completeSelector = appendToSelectors(decl.parent.selector, selector);
+
+    block = decl.parent.cloneAfter({
+          selector: completeSelector
         }),
         props = props || [],
         values = values || [];


### PR DESCRIPTION
I'm using Lost to create a predefined grid with column classes like `.col1of2`, `.col3of4` etc. All fractions that can be simplified are done so with @extend (using Stylus to generate the CSS in my case). An example is:

```css
.width1of1,
.width2of2 {
  lost-column: 1/1;
}
```

When I run this with Lost I get the following result 

```css
.width1of1,
.width2of2 { // css}

.width1of1,
.width2of2:nth-child(n) { // css }

.width1of1,
.width2of2:last-child { // css }

.width1of1,
.width2of2:nth-child(1n) { // css }

.width1of1,
.width2of2:nth-child(1n + 1) { // css }
```

The issue is that only the last selector in the list of selectors gets appended with the pseudo classes. My expectation was that Lost would compile to this:

```css
.width1of1,
.width2of2 { // css}

.width1of1:nth-child(n),
.width2of2:nth-child(n) { // css }

.width1of1:last-child,
.width2of2:last-child { // css }

.width1of1:nth-child(1n),
.width2of2:nth-child(1n) { // css }

.width1of1:nth-child(1n + 1),
.width2of2:nth-child(1n + 1) { // css }
```

Is the current behavior intended? If not this PR is a suggestion to fix it.