### PR TITLE
Move default settings declarations so passed option arguments apply

### DIFF
--- a/lost.js
+++ b/lost.js
@@ -30,15 +30,14 @@ module.exports = postcss.plugin('lost', function lost(settings) {
     });
   };
 
-  settings = settings || {};
-
-  settings = assign(settings, {
-    gutter: '30px',
-    flexbox: 'no-flex',
-    cycle: 'auto'
-  });
-
   return function (css) {
+
+    settings = settings || {};
+
+    settings.gutter = settings.gutter || '30px';
+    settings.flexbox = settings.flexbox || 'no-flex';
+    settings.cycle = settings.cycle || 'auto';
+
     /**
      * Override global settings from at-rules set in stylesheet.
      *


### PR DESCRIPTION

I’m integrating Lost into an NPM module and found the options I passed
through as arguments were coming out as “undefined”.

Two things in combination seemed to allow passed options to take effect:

1. Moving the settings into the css function
2. Adding || to each line to preserve passed settings

Hopefully this doesn’t mess with anything else in the code.