### PR TITLE
Make play nice with later postcss plugins

### DIFF
--- a/lost.js
+++ b/lost.js
@@ -124,16 +124,16 @@ module.exports = postcss.plugin('lost', function lost(settings) {
 
         newBlock(
           decl,
-          ':after, :before',
-          ['content', 'display'],
-          ['\'\'', 'table']
+          ':after',
+          ['content', 'display', 'clear'],
+          ['\'\'', 'table', 'both']
         );
 
         newBlock(
           decl,
-          ':after',
-          ['clear'],
-          ['both']
+          ':before',
+          ['content', 'display'],
+          ['\'\'', 'table']
         );
       }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lost",
-  "version": "6.4.0",
+  "version": "6.5.0",
   "description": "PostCSS fractional grid system built with calc() by the guy who built Jeet. Supports masonry, vertical, and waffle grids.",
   "main": "lost.js",
   "repository": {


### PR DESCRIPTION
I'm using this library with webpack's `css-loader`. Because `css-loader` transforms class names, I ended up with a global `:before` selector.

I know the CSS is a little longer, but it's kinda broken otherwise...

Thanks for the awesome library!

Oh, and it fixes #143.